### PR TITLE
Fix EFAULT on some platforms.

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -87,8 +87,8 @@ printf "\x01\x00"
 printf "\x00\x00"
 # 3c
 # ELF header: number of entries in section header tbl
-# ELF program header: flags (1 = executable)
-printf "\x01\x00"
+# ELF program header: flags (1 = executable, 4 = readable, 5 = r+x)
+printf "\x05\x00"
 # 3e
 # ELF header: section idx to section hdr tbl
 # ELF program header: flags cont'd


### PR DESCRIPTION
The program header was marked as exec,
despite the fact that it contained
data that needed to be read by the kernel.
The write syscall would efault as the
kernel was unable to read the address.

On some versions of the kernel exec
is treated as read but on others it
only allows execution.

We now explicitly mark the section as read+exec.